### PR TITLE
Mock RBAC, entitlements for mock SSO

### DIFF
--- a/crcmocks/config.py
+++ b/crcmocks/config.py
@@ -16,6 +16,24 @@ PORT = int(os.getenv("PORT", 9000))
 
 SECRET_KEY = os.getenv("FLASK_SECRET_KEY", os.urandom(32))
 
+DEFAULT_SERVICES = [
+    "ansible",
+    "cost_management",
+    "insights",
+    "advisor",
+    "migrations",
+    "openshift",
+    "settings",
+    "smart_management",
+    "subscriptions",
+    "user_preferences",
+]
+
+DEFAULT_PERMISSIONS = [
+    "advisor:*:*",
+    "inventory:*:*",
+]
+
 DEFAULT_USERS = [
     {
         "username": "jdoe",
@@ -30,5 +48,7 @@ DEFAULT_USERS = [
         "org_id": "3340852",
         "is_org_admin": False,
         "is_internal": False,
+        "entitlements": ",".join(DEFAULT_SERVICES),
+        "permissions": ",".join(DEFAULT_PERMISSIONS)
     }
 ]

--- a/crcmocks/entitlements.py
+++ b/crcmocks/entitlements.py
@@ -1,28 +1,40 @@
 from flask import jsonify
 from flask import Blueprint
+from flask import request
+
+from crcmocks.config import DEFAULT_SERVICES
+from crcmocks.util import get_user_rh_identity
 
 
 blueprint = Blueprint("entitlements", __name__)
 
 
-services = [
-    "ansible",
-    "cost_management",
-    "insights",
-    "advisor",
-    "migrations",
-    "openshift",
-    "settings",
-    "smart_management",
-    "subscriptions",
-    "user_preferences",
-]
-entitlements = {}
-for svc in services:
-    entitlements[svc] = {"is_entitled": True, "is_trial": False}
-
-
-# TODO: allow customizable entitlements response per user
+# TODO: support is_trial?
 @blueprint.route("/v1/services")
 def services():
-    return jsonify(entitlements)
+    # get the identity header
+    identity_header = request.headers.get("X-Rh-Identity")
+
+    if identity_header is None:
+        return "No identity header present in request\n", 401
+
+    # get the user
+    user, username, account_number = get_user_rh_identity(identity_header)
+
+    if not user:
+        return f"No user found in TinyDB with username:" \
+               f" {username} or account_number: {account_number}\n", 404
+    if len(user) > 1:
+        return f"Multiple users found with:" \
+               f" {username} or account_number: {account_number}\n", 406
+
+    # finally get the entitlements of the user
+    if user[0].get("entitlements") is not None:
+        entitled_services = user[0]["entitlements"].split(",")
+    else:
+        entitled_services = DEFAULT_SERVICES.copy()
+
+    entitlements = {}
+    for svc in DEFAULT_SERVICES:
+        entitlements[svc] = {"is_entitled": svc in entitled_services, "is_trial": False}
+    return jsonify(entitlements), 200

--- a/crcmocks/rbac.py
+++ b/crcmocks/rbac.py
@@ -1,33 +1,83 @@
+from copy import deepcopy
+
 from flask import jsonify
 from flask import Blueprint
+from flask import request
+
+from crcmocks.util import get_user_rh_identity
+from crcmocks.config import DEFAULT_PERMISSIONS
 
 
 blueprint = Blueprint("rbac", __name__)
 
-rbac_response = {
-    "meta": {"count": 30, "limit": 1000, "offset": 0},
+BASE_RBAC_RESPONSE = {
+    "meta": {"count": None, "limit": None, "offset": 0},
     "links": {
         "first": "/api/rbac/v1/access/?application=&format=json&limit=1000&offset=0",
         "next": None,
         "previous": None,
         "last": "/api/rbac/v1/access/?application=&format=json&limit=1000&offset=0",
     },
-    "data": [
-        {"resourceDefinitions": [], "permission": "advisor:*:*"},
-        {"resourceDefinitions": [], "permission": "inventory:*:*"},
-        {"resourceDefinitions": [], "permission": "inventory:*:read"},
-        {"resourceDefinitions": [], "permission": "inventory:*:read"},
-        {"resourceDefinitions": [], "permission": "inventory:*:read"},
-        {"resourceDefinitions": [], "permission": "inventory:*:read"},
-        {"resourceDefinitions": [], "permission": "inventory:*:read"},
-        {"resourceDefinitions": [], "permission": "inventory:*:*"},
-        {"resourceDefinitions": [], "permission": "inventory:*:read"},
-        {"resourceDefinitions": [], "permission": "inventory:*:read"},
-    ],
+    "data": [],
 }
 
 
-# TODO: allow customizable rbac response per user
-@blueprint.route("/v1/access/")
+# TODO: support resource definitions?
+@blueprint.route("/v1/access/", methods=["GET"])
 def rbac_access():
+    application = request.args.get("application")
+    limit = int(request.args.get("limit", 100))
+    offset = int(request.args.get("offset", 0))
+    # get the identity header
+    identity_header = request.headers.get("X-Rh-Identity")
+
+    if identity_header is None:
+        return "No identity header present in request\n", 401
+
+    # get the user
+    user, username, account_number = get_user_rh_identity(identity_header)
+
+    if not user:
+        return f"No user found in TinyDB with username:" \
+               f" {username} or account_number: {account_number}\n", 404
+    if len(user) > 1:
+        return f"Multiple users found with:" \
+               f" {username} or account_number: {account_number}\n", 406
+
+    # get the user permissions
+    if user[0].get("entitlements") is not None:
+        permissions = user[0]["permissions"].split(",")
+    else:
+        permissions = DEFAULT_PERMISSIONS.copy()
+
+    rbac_response = deepcopy(BASE_RBAC_RESPONSE)
+    # set links
+    rbac_response["links"]["first"] = f"/api/rbac/v1/access/?application={application or ''}" \
+                                      f"&format=json&limit={limit}" \
+                                      f"&offset={offset}"
+    rbac_response["links"]["last"] = f"/api/rbac/v1/access/?application={application or ''}" \
+                                     f"&format=json&limit={limit}" \
+                                     f"&offset={offset}"
+
+    limit_count = 0
+    # TODO: implement 'real' pagination
+    for i, perm in enumerate(permissions):
+        if i >= offset:
+            if application:
+                if perm.split(":")[0] in application:
+                    rbac_response["data"].append(
+                        {"resourceDefinitions": [], "permission": perm}
+                    )
+                    limit_count += 1
+            else:
+                rbac_response["data"].append(
+                    {"resourceDefinitions": [], "permission": perm}
+                )
+                limit_count += 1
+            if limit_count == limit:
+                break
+    # set meta
+    rbac_response["meta"]["limit"] = limit
+    rbac_response["meta"]["count"] = limit_count
+
     return jsonify(rbac_response)

--- a/crcmocks/templates/new_user_form.html
+++ b/crcmocks/templates/new_user_form.html
@@ -20,6 +20,12 @@
     <p>
     </p>
         {{ form.password.label }}{{ form.password }}
+    <p>
+    </p>
+        {{ form.entitlements.label}}{{ form.entitlements }}
+    <p>
+    </p>
+        {{ form.permissions.label}}{{ form.permissions }}
     </p>
     <p>{{ form.submit() }}</p>
 </form>

--- a/crcmocks/templates/user_list.html
+++ b/crcmocks/templates/user_list.html
@@ -20,16 +20,20 @@
             <th>email</th>
             <th>org_id</th>
             <th>account_number</th>
+            <th>permissions</th>
+            <th>entitlements</th>
         </tr>
         {% for ruser in rusers %}
             <tr>
                 <td>{{ ruser.id }}</td>
                 <td>{{ ruser.username }}</td>
-                <td>{{ ruser.attributes.first_name[0] }}</td>
-                <td>{{ ruser.attributes.last_name[0] }}</td>
+                <td>{{ ruser.first_name }}</td>
+                <td>{{ ruser.last_name }}</td>
                 <td>{{ ruser.email }}</td>
-                <td>{{ ruser.attributes.org_id[0] }}</td>
-                <td>{{ ruser.attributes.account_number[0] }}</td>
+                <td>{{ ruser.org_id }}</td>
+                <td>{{ ruser.account_number }}</td>
+                <td>{{ ruser.permissions }}</td>
+                <td>{{ ruser.entitlements }} </td>
             <tr>
         {% endfor %}
         </table>

--- a/crcmocks/util/__init__.py
+++ b/crcmocks/util/__init__.py
@@ -1,0 +1,7 @@
+from .query import get_user_rh_identity
+from .query import get_users
+
+__all__ = [
+    get_user_rh_identity,
+    get_users
+]

--- a/crcmocks/util/query.py
+++ b/crcmocks/util/query.py
@@ -1,0 +1,30 @@
+import json
+from base64 import b64decode
+
+from crcmocks.db import user_db
+from crcmocks.db import query
+
+
+def get_user_rh_identity(identity_header):
+    """
+    Given an base64 encoded identity header, find a user.
+    """
+    # decode the identity header
+    identity_header = json.loads(b64decode(identity_header.encode("ascii")).decode('ascii'))
+    account_number = identity_header.get("identity", {}).get("account_number")
+    username = identity_header.get("identity", {}).get("user", {}).get("username")
+
+    # lookup the user in tinyDB, based on the identity
+    return user_db.search(
+        (query.account_number.search(str(account_number))) | (query.username == username)
+    ), username, account_number
+
+
+def get_users():
+    """
+    Get all users in TinyDB.
+
+    This is different from kc_helper.get_realm_users() in that it returns permission/entitlement
+    information, which is not stored in keycloak.
+    """
+    return user_db.all()


### PR DESCRIPTION
* Added `entitlements` and `permissions` fields to user model in TinyDB, these are string fields that are just comma-separated lists:
```
entitlements: "advisor,ansible,settings"
```
* Added `entitlements` and `permissions` fields to UI table and form
* Added code to examine `X-Rh-Identity` header in requests and lookup user in TinyDB and return entitlements/permissions present on the user. If `entitlements/permissions` are `None`, return defaults

Meant to address #2, note that this PR does not handle `resourceDefinitions` or the `is_trial` part of the `entitlements` endpoint. 