### PR TITLE
Fix entitlements/permissions

### DIFF
--- a/crcmocks/entitlements.py
+++ b/crcmocks/entitlements.py
@@ -34,7 +34,7 @@ def services():
         )
 
     # finally get the entitlements of the user
-    if user[0].get("entitlements") is not None:
+    if user[0].get("entitlements"):
         entitled_services = user[0]["entitlements"].split(",")
     else:
         entitled_services = DEFAULT_SERVICES.copy()

--- a/crcmocks/rbac.py
+++ b/crcmocks/rbac.py
@@ -50,7 +50,7 @@ def rbac_access():
         )
 
     # get the user permissions
-    if user[0].get("entitlements") is not None:
+    if user[0].get("permissions"):
         permissions = user[0]["permissions"].split(",")
     else:
         permissions = DEFAULT_PERMISSIONS.copy()


### PR DESCRIPTION
When deploying an ephemeral frontend, I noticed that if I didn't input anything for the entitlements or permissions of a user, the result would be an empty string.

This caused the API request to consider the user to have permissions/entitlements defined and as a result empty lists would be returned. 