### PR TITLE
Support for persistent storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Once you have the `crcmocks` API service running (it listens on port 9000 by def
 * `POST /_shutdown` -- shuts down the flask API
 * `POST /_manager/addUser` -- allows you to create new test user with JSON
 * `GET /_manager/users` -- returns JSON listing all users created in keycloak
+* `POST /_manager/resetUsers` -- resets users back to default configurations
 
 ### Management UI
 

--- a/crcmocks/db.py
+++ b/crcmocks/db.py
@@ -1,19 +1,29 @@
+import logging
+
 from tinydb import Query
 from tinydb import TinyDB
-from tinydb.storages import MemoryStorage
 
+log = logging.getLogger(__name__)
 
-user_db = TinyDB(storage=MemoryStorage)
-request_db = TinyDB(storage=MemoryStorage)
-query = Query()
+user_db = TinyDB("/opt/tinydb/data/user_db.json")
+request_db = TinyDB("/opt/tinydb/data/request_db.json")
+User = Query()
 
 
 def all_users():
     return user_db.all()
 
 
-def add_user(data):
-    user_db.upsert(data, query.username == data["username"])
+def add_user(data, skip_if_exists=False):
+    if skip_if_exists and user_db.search(User.username == data["username"]):
+        log.info("skipping localdb update for existing user: %s", data["username"])
+        return
+    user_db.upsert(data, User.username == data["username"])
+    log.info("added/updated user in localdb: %s", data["username"])
+
+
+def clear_users():
+    user_db.truncate()
 
 
 def all_requests():
@@ -25,4 +35,4 @@ def add_request(data):
 
 
 def clear_requests():
-    request_db.purge()
+    request_db.truncate()

--- a/crcmocks/keycloak_helper.py
+++ b/crcmocks/keycloak_helper.py
@@ -156,6 +156,7 @@ class KeyCloakHelper:
         is_org_admin,
         is_internal,
         is_active,
+        skip_if_exists=False,
     ):
         user_json = {
             "enabled": True,
@@ -178,12 +179,17 @@ class KeyCloakHelper:
         for user in self.get_realm_users():
             if user["username"] == uname:
                 # user already exists
+                if skip_if_exists:
+                    log.info("skipping localdb update for existing user: %s", uname)
+                    break
                 user_id = user["id"]
                 self.realm_admin.update_user(user_id, user_json)
+                log.info("updated user in keycloak: %s", uname)
                 break
         else:
             # user does not already exist
             self.realm_admin.create_user(user_json)
+            log.info("created user in keycloak: %s", uname)
 
 
 kc_helper = KeyCloakHelper()

--- a/crcmocks/util/query.py
+++ b/crcmocks/util/query.py
@@ -1,7 +1,7 @@
 import json
 from base64 import b64decode
 
-from crcmocks.db import query
+from crcmocks.db import User
 from crcmocks.db import user_db
 
 
@@ -17,7 +17,7 @@ def get_user_rh_identity(identity_header):
     # lookup the user in tinyDB, based on the identity
     return (
         user_db.search(
-            (query.account_number.search(str(account_number))) | (query.username == username)
+            (User.account_number.search(str(account_number))) | (User.username == username)
         ),
         username,
         account_number,
@@ -30,5 +30,7 @@ def get_users():
 
     This is different from kc_helper.get_realm_users() in that it returns permission/entitlement
     information, which is not stored in keycloak.
+
+    Perhaps in future this function will allow for some filtering of results as well
     """
     return user_db.all()

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -71,11 +71,34 @@ objects:
   - kind: ServiceAccount
     name: mocks-sa
 
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: mocks-data
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: "1Gi"
+
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: keycloak-data
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: "1Gi"
+
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
     labels:
       app: mocks
+      name: mocks
     name: mocks
   spec:
     minReadySeconds: 15
@@ -86,10 +109,7 @@ objects:
       matchLabels:
         name: mocks
     strategy:
-      rollingUpdate:
-        maxSurge: 25%
-        maxUnavailable: 25%
-      type: RollingUpdate
+      type: Recreate
     template:
       metadata:
         labels:
@@ -126,6 +146,46 @@ objects:
             value: ${GW_DEPLOYMENT}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
+          volumeMounts:
+          - mountPath: /opt/tinydb/data/
+            name: mocks-data
+        dnsPolicy: ClusterFirst
+        imagePullSecrets:
+        - name: quay-cloudservices-pull
+        - name: rh-registry-pull
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+        volumes:
+        - name: mocks-data
+          persistentVolumeClaim:
+            claimName: mocks-data
+
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: mocks
+      name: keycloak
+    name: keycloak
+  spec:
+    minReadySeconds: 15
+    progressDeadlineSeconds: 600
+    replicas: ${{REPLICAS}}
+    revisionHistoryLimit: 9
+    selector:
+      matchLabels:
+        name: keycloak
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          app: mocks
+          name: keycloak
+      spec:
+        containers:
         - image: ${KEYCLOAK_IMAGE}:${KEYCLOAK_IMAGE_TAG}
           imagePullPolicy: Always
           name: keycloak
@@ -144,12 +204,15 @@ objects:
           resources:
             limits:
               cpu: 500m
-              memory: 512Mi
+              memory: 1024Mi
             requests:
               cpu: 250m
-              memory: 128Mi
+              memory: 512Mi
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
+          volumeMounts:
+          - mountPath: /opt/jboss/keycloak/standalone/data/
+            name: keycloak-data
         dnsPolicy: ClusterFirst
         imagePullSecrets:
         - name: quay-cloudservices-pull
@@ -158,6 +221,10 @@ objects:
         schedulerName: default-scheduler
         securityContext: {}
         terminationGracePeriodSeconds: 30
+        volumes:
+        - name: keycloak-data
+          persistentVolumeClaim:
+            claimName: keycloak-data
 
 - apiVersion: v1
   kind: Service
@@ -171,6 +238,7 @@ objects:
       targetPort: 9000
     selector:
       app: mocks
+      name: mocks
     sessionAffinity: None
     type: ClusterIP
 
@@ -216,6 +284,7 @@ objects:
       targetPort: 8080
     selector:
       app: mocks
+      name: keycloak
     sessionAffinity: None
     type: ClusterIP
 


### PR DESCRIPTION
If the mocks or keycloaks containers restart, they lose data. This PR adds support for persistent data.