### PR TITLE
fix redirect uri for KEYCLOAK_CLIENT_BASE_URL="*"

### DIFF
--- a/crcmocks/keycloak_helper.py
+++ b/crcmocks/keycloak_helper.py
@@ -132,17 +132,20 @@ class KeyCloakHelper:
         ]
 
         # TODO: service accouts enabled == True, authorization enabled = True
-        self.realm_admin.create_client(
-            {
-                "clientId": client,
-                "enabled": True,
-                "bearerOnly": False,
-                "publicClient": True,
-                "baseUrl": f"{self.client_base_url}",
-                "redirectUris": [f"{self.client_base_url}/*"],
-                "protocolMappers": protocol_mappers,
-            }
-        )
+        post_body = {
+            "clientId": client,
+            "enabled": True,
+            "bearerOnly": False,
+            "publicClient": True,
+            "redirectUris": [self.client_base_url],
+            "webOrigins": [self.client_base_url],
+            "protocolMappers": protocol_mappers,
+        }
+        if self.client_base_url.startswith("http"):
+            post_body["baseUrl"] = self.client_base_url
+            post_body["redirectUris"] = [uri + "/*" for uri in post_body["redirectUris"]]
+
+        self.realm_admin.create_client(post_body)
 
     def upsert_realm_user(
         self,


### PR DESCRIPTION
I've gotten this repo working with https://github.com/RedHatInsights/insights-standalone except for some keycloak redirectUri and webOrigins fields that need tweaking for localhost rather than the aggregator.