### PR TITLE
Create services for rbac/entitlements dynamically

### DIFF
--- a/crcmocks/config.py
+++ b/crcmocks/config.py
@@ -7,8 +7,9 @@ def env_bool(var_name, default):
 
 INITIALIZE_FE = env_bool("INITIALIZE_FE", False)
 INITIALIZE_GW = env_bool("INITIALIZE_GW", False)
-GW_MOCK_ENTITLEMENTS = env_bool("GW_MOCK_ENTITLEMENTS", True)
-GW_MOCK_BOP = env_bool("GW_MOCK_BOP", True)
+MOCK_ENTITLEMENTS = env_bool("MOCK_ENTITLEMENTS", True)
+MOCK_BOP = env_bool("MOCK_BOP", True)
+MOCK_BOP = env_bool("MOCK_RBAC", True)
 
 FE_DEPLOYMENT = os.getenv("FE_DEPLOYMENT", "front-end-aggregator")
 GW_DEPLOYMENT = os.getenv("GW_DEPLOYMENT", "apicast")

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -136,10 +136,12 @@ objects:
             value: ${INITIALIZE_FE}
           - name: INITIALIZE_GW
             value: ${INITIALIZE_GW}
-          - name: GW_MOCK_ENTITLEMENTS
-            value: ${GW_MOCK_ENTITLEMENTS}
-          - name: GW_MOCK_BOP
-            value: ${GW_MOCK_BOP}
+          - name: MOCK_ENTITLEMENTS
+            value: ${MOCK_ENTITLEMENTS}
+          - name: MOCK_RBAC
+            value: ${MOCK_RBAC}
+          - name: MOCK_BOP
+            value: ${MOCK_BOP}
           - name: FE_DEPLOYMENT
             value: ${FE_DEPLOYMENT}
           - name: GW_DEPLOYMENT
@@ -245,38 +247,6 @@ objects:
 - apiVersion: v1
   kind: Service
   metadata:
-    name: rbac
-  spec:
-    ports:
-    - name: 8080-tcp
-      port: 8080
-      protocol: TCP
-      targetPort: 9000
-    selector:
-      app: mocks
-      name: mocks
-    sessionAffinity: None
-    type: ClusterIP
-
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: entitlements-api-go
-  spec:
-    ports:
-    - name: 3000-tcp
-      port: 3000
-      protocol: TCP
-      targetPort: 9000
-    selector:
-      app: mocks
-      name: mocks
-    sessionAffinity: None
-    type: ClusterIP
-
-- apiVersion: v1
-  kind: Service
-  metadata:
     name: keycloak
   spec:
     ports:
@@ -342,9 +312,11 @@ parameters:
   value: "true"
 - name: INITIALIZE_GW
   value: "true"
-- name: GW_MOCK_ENTITLEMENTS
+- name: MOCK_ENTITLEMENTS
   value: "true"
-- name: GW_MOCK_BOP
+- name: MOCK_BOP
+  value: "true"
+- name: MOCK_RBAC
   value: "true"
 - name: FE_DEPLOYMENT
   value: "front-end-aggregator"

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -2,7 +2,7 @@ export IMAGE="quay.io/cloudservices/mocks"  # the image location on quay
 
 # Install bonfire repo/initialize
 CICD_URL=https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd
-curl $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
+curl -sS $CICD_URL/bootstrap.sh -o $WORKSPACE/.cicd_bootstrap.sh && source $WORKSPACE/.cicd_bootstrap.sh
 
 # Build the image and push to quay
 source $CICD_ROOT/build.sh

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -2,7 +2,7 @@ export IMAGE="quay.io/cloudservices/mocks"  # the image location on quay
 
 # Install bonfire repo/initialize
 CICD_URL=https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd
-curl -sS $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
+curl $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
 
 # Build the image and push to quay
 source $CICD_ROOT/build.sh

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,2 +1,26 @@
-echo "todo..."
-exit 0
+export IMAGE="quay.io/cloudservices/mocks"  # the image location on quay
+
+# Install bonfire repo/initialize
+CICD_URL=https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd
+curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
+
+# Build the image and push to quay
+source $CICD_ROOT/build.sh
+
+# Test that the deployment works
+source ${CICD_ROOT}/_common_deploy_logic.sh
+export NAMESPACE=$(bonfire namespace reserve)
+bonfire deploy \
+    gateway insights-ephemeral \
+    --source=appsre \
+    --set-template-ref mocks=${GIT_COMMIT} \
+    --set-image-tag ${IMAGE}=${IMAGE_TAG} \
+    --namespace ${NAMESPACE} \
+
+# Create a 'dummy' junit result file so Jenkins will not fail
+mkdir -p $WORKSPACE/artifacts
+cat << EOF > $WORKSPACE/artifacts/junit-dummy.xml
+<testsuite tests="1">
+    <testcase classname="dummy" name="dummytest"/>
+</testsuite>
+EOF

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -2,7 +2,7 @@ export IMAGE="quay.io/cloudservices/mocks"  # the image location on quay
 
 # Install bonfire repo/initialize
 CICD_URL=https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd
-curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
+curl -sS $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
 
 # Build the image and push to quay
 source $CICD_ROOT/build.sh


### PR DESCRIPTION
Instead of creating the Service via the OpenShift template (which is not customizable), the env vars MOCK_RBAC and MOCK_ENTITLEMENTS will now control whether those service resources are created in the namespace. The mocks' initializer will now take care of adding those services.