### PR TITLE
Ignore removal of nonexistent files

### DIFF
--- a/crcmocks/initializer.py
+++ b/crcmocks/initializer.py
@@ -98,7 +98,7 @@ def initialize_fe(namespace):
         f"cd /all/code/chrome/js && "
         "for f in `ls *.js`; "
         f"do sed -i s/{qa_host}/{keycloak_host}/g $f && "
-        "rm $f.gz && "
+        "rm -f $f.gz && "
         "gzip --keep $f; "
         "done"
     )


### PR DESCRIPTION
Resolves an issue found in ephemeral where mocks fails to start due to errors when attempting to delete nonexistent files in the frontend aggregator.